### PR TITLE
feat(add): MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Seongrok(Mark) Shin
+Copyright (c) 2024 Seongrok Shin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Context:

The project needed a proper license to clarify terms of use and distribution rights for potential contributors and users. The MIT License was chosen as it aligns with the project's open-source nature mentioned in the README.

## Intent:

- Add MIT License file to the project root
- Establish clear terms for software usage and distribution
- Enable collaboration while protecting author rights

## Note:

License is set with copyright holder as "Seongrok Shin" and year 2024