### PR TITLE
feat(add): blog components and centralize prop types

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    domains: ["via.placeholder.com", "github.com"],
+  },
+  // Add any other configuration options below
+};
+
+module.exports = nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    domains: ["via.placeholder.com"],
+  },
 };
 
 export default nextConfig;

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,68 @@
+/**
+ * Copyright (c) 2025 Seongrok Shin
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PostList from "@/components/blog/PostList";
+
+// Sample data - This would typically come from a database or API
+const samplePosts = [
+  {
+    title: "Getting Started with Next.js",
+    excerpt:
+      "Learn how to build modern web applications with Next.js, React, and TypeScript.",
+    slug: "getting-started-with-nextjs",
+    date: "2025-01-01",
+    author: {
+      name: "Seongrok Shin",
+      image: "https://github.com/Seongrok-Shin.png",
+    },
+    coverImage: "https://via.placeholder.com/800x400",
+  },
+  {
+    title: "Building a Blog Platform",
+    excerpt:
+      "A comprehensive guide to creating a full-featured blog platform using modern web technologies.",
+    slug: "building-a-blog-platform",
+    date: "2025-01-02",
+    author: {
+      name: "Seongrok Shin",
+      image: "https://github.com/Seongrok-Shin.png",
+    },
+    coverImage: "https://via.placeholder.com/800x400",
+  },
+  {
+    title: "Styling with Tailwind CSS",
+    excerpt:
+      "Learn how to create beautiful, responsive designs using Tailwind CSS utility classes.",
+    slug: "styling-with-tailwind-css",
+    date: "2025-01-03",
+    author: {
+      name: "Seongrok Shin",
+      image: "https://github.com/Seongrok-Shin.png",
+    },
+    coverImage: "https://via.placeholder.com/800x400",
+  },
+];
+
 export default function BlogPage() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold">Blog</h1>
-      <p className="mt-4 text-gray-600">Blog content coming soon...</p>
+    <div className="py-8">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Latest Posts
+          </h1>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-gray-600">
+            Discover the latest insights, tutorials, and thoughts on web
+            development, design, and technology.
+          </p>
+        </div>
+      </div>
+      <div className="mt-12">
+        <PostList posts={samplePosts} />
+      </div>
     </div>
   );
 }

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2025 Seongrok Shin
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import type { PostCardProps } from "@/types/blog";
+
+export default function PostCard({
+  title,
+  excerpt,
+  slug,
+  date,
+  author,
+  coverImage,
+}: PostCardProps) {
+  return (
+    <article className="flex flex-col overflow-hidden rounded-lg border shadow-sm transition-shadow hover:shadow-md">
+      {coverImage && (
+        <div className="relative h-48 w-full">
+          <Image
+            src={coverImage}
+            alt={title}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          />
+        </div>
+      )}
+      <div className="flex flex-1 flex-col justify-between p-6">
+        <div className="flex-1">
+          <Link href={`/blog/${slug}`} className="mt-2 block">
+            <h3 className="text-xl font-semibold text-gray-900 hover:text-primary">
+              {title}
+            </h3>
+            <p className="mt-3 text-base text-gray-500 line-clamp-3">
+              {excerpt}
+            </p>
+          </Link>
+        </div>
+        <div className="mt-6 flex items-center">
+          <div className="relative h-10 w-10 flex-shrink-0">
+            <Image
+              src={author.image}
+              alt={author.name}
+              className="rounded-full"
+              fill
+              sizes="40px"
+            />
+          </div>
+          <div className="ml-3">
+            <p className="text-sm font-medium text-gray-900">{author.name}</p>
+            <div className="flex space-x-1 text-sm text-gray-500">
+              <time dateTime={new Date(date).toISOString()}>{date}</time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/blog/PostList.tsx
+++ b/src/components/blog/PostList.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025 Seongrok Shin
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PostCard from "./PostCard";
+import type { PostListProps } from "@/types/blog";
+
+export default function PostList({ posts }: PostListProps) {
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => (
+          <PostCard key={post.slug} {...post} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,27 @@
+export interface PostCardProps {
+  title: string;
+  excerpt: string;
+  slug: string;
+  date: string;
+  author: {
+    name: string;
+    image: string;
+  };
+  coverImage?: string;
+}
+
+export interface Post {
+  title: string;
+  excerpt: string;
+  slug: string;
+  date: string;
+  author: {
+    name: string;
+    image: string;
+  };
+  coverImage?: string;
+}
+
+export interface PostListProps {
+  posts: Post[];
+}

--- a/tests/blog.spec.ts
+++ b/tests/blog.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+
+// Test suite for the Blog Page
+test.describe("Blog Page", () => {
+  test.beforeEach(async ({ page }) => {
+    // navigate to the blog page
+    await page.goto("/blog");
+  });
+
+  test("should display blog header and sample posts", async ({ page }) => {
+    // Check the main blog header
+    await expect(
+      page.getByRole("heading", { name: "Latest Posts" }),
+    ).toBeVisible();
+
+    // Check for the blog description text
+    await expect(page.getByText(/Discover the latest insights/)).toBeVisible();
+
+    // Verify that the sample posts are rendered
+    const posts = [
+      "Getting Started with Next.js",
+      "Building a Blog Platform",
+      "Styling with Tailwind CSS",
+    ];
+
+    for (const postTitle of posts) {
+      // Each post's title should be rendered as a link
+      await expect(page.getByRole("link", { name: postTitle })).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
## Context:
The blog section was previously unstructured and lacked dedicated, reusable components. To make the blog scalable and maintainable, I needed to build a set of components to display and manage blog posts along with a centralized system for type consistency.

## Intent:
- Create a PostCard component to display individual blog post previews including the cover image, title, excerpt, publication date, and author details.
- Develop a PostList component that arranges multiple PostCard components in a responsive grid layout.
- Update the blog page (/blog/page.tsx) to integrate the new PostList component using sample data, improving the design and presentation of the latest posts.
- Centralize all blog-related prop types (PostCardProps, Post, PostListProps) into a single file (src/types/blog.ts) to avoid duplication and ensure consistent type usage across the blog components.

## Note:
This commit introduces new, reusable components and better organization for the blog section without affecting the existing functionality.