### PR TITLE
feat(add): Implement Blog Post Page & Fix Mobile Sidebar Overlap

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,98 @@
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import type { Post } from "@/types/blog";
+
+// Sample posts data. In a real app, you would fetch data from a CMS or database.
+const samplePosts: Post[] = [
+  {
+    title: "Getting Started with Next.js",
+    excerpt:
+      "Learn how to build modern web applications with Next.js, React, and TypeScript.",
+    slug: "getting-started-with-nextjs",
+    date: "2025-01-01",
+    author: {
+      name: "Seongrok Shin",
+      image: "https://github.com/Seongrok-Shin.png",
+    },
+    coverImage: "https://via.placeholder.com/800x400",
+  },
+  {
+    title: "Building a Blog Platform",
+    excerpt:
+      "A comprehensive guide to creating a full-featured blog platform using modern web technologies.",
+    slug: "building-a-blog-platform",
+    date: "2025-01-02",
+    author: {
+      name: "Seongrok Shin",
+      image: "https://github.com/Seongrok-Shin.png",
+    },
+    coverImage: "https://via.placeholder.com/800x400",
+  },
+  {
+    title: "Styling with Tailwind CSS",
+    excerpt:
+      "Learn how to create beautiful, responsive designs using Tailwind CSS utility classes.",
+    slug: "styling-with-tailwind-css",
+    date: "2025-01-03",
+    author: {
+      name: "Seongrok Shin",
+      image: "https://github.com/Seongrok-Shin.png",
+    },
+    coverImage: "https://via.placeholder.com/800x400",
+  },
+];
+
+// Helper function to get a post by slug
+function getPostBySlug(slug: string): Post | undefined {
+  return samplePosts.find((post) => post.slug === slug);
+}
+
+interface PageProps {
+  params: { slug: string };
+}
+
+export default function BlogPostPage({ params }: PageProps) {
+  const post = getPostBySlug(params.slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <article className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-4xl font-bold text-gray-900">{post.title}</h1>
+      <div className="mt-4 text-gray-600">
+        <time dateTime={new Date(post.date).toISOString()}>{post.date}</time>
+      </div>
+      {post.coverImage && (
+        <div className="relative mt-6 h-64 w-full z-0">
+          <Image
+            src={post.coverImage}
+            alt={post.title}
+            fill
+            className="object-cover"
+          />
+        </div>
+      )}
+      <p className="mt-6 text-lg text-gray-700">{post.excerpt}</p>
+      <div className="mt-8 flex items-center gap-4">
+        <div className="relative h-10 w-10">
+          <Image
+            src={post.author.image}
+            alt={post.author.name}
+            fill
+            className="rounded-full"
+          />
+        </div>
+        <span className="text-sm font-medium">{post.author.name}</span>
+      </div>
+      <Link
+        href="/blog"
+        className="mt-8 inline-block text-primary hover:underline"
+      >
+        &larr; Back to Blog
+      </Link>
+    </article>
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -51,9 +51,9 @@ function getPostBySlug(slug: string): Post | undefined {
 export default async function BlogPostPage({
   params,
 }: {
-  params: { slug: string };
+  params: { slug: string } | Promise<{ slug: string }>;
 }) {
-  const resolvedParams = await Promise.resolve(params);
+  const resolvedParams = await params;
   const post = getPostBySlug(resolvedParams.slug);
 
   if (!post) {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import type { Post } from "@/types/blog";
+import type { Post, PostParams } from "@/types/blog";
 
 // Sample posts data. In a real app, you would fetch data from a CMS or database.
 const samplePosts: Post[] = [
@@ -48,13 +48,9 @@ function getPostBySlug(slug: string): Post | undefined {
   return samplePosts.find((post) => post.slug === slug);
 }
 
-export default async function BlogPostPage({
-  params,
-}: {
-  params: { slug: string } | Promise<{ slug: string }>;
-}) {
-  const resolvedParams = await params;
-  const post = getPostBySlug(resolvedParams.slug);
+export default async function BlogPostPage({ params }: { params: PostParams }) {
+  const slug = await params;
+  const post = getPostBySlug(slug.slug);
 
   if (!post) {
     notFound();

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -48,12 +48,13 @@ function getPostBySlug(slug: string): Post | undefined {
   return samplePosts.find((post) => post.slug === slug);
 }
 
-interface PageProps {
+export default async function BlogPostPage({
+  params,
+}: {
   params: { slug: string };
-}
-
-export default function BlogPostPage({ params }: PageProps) {
-  const post = getPostBySlug(params.slug);
+}) {
+  const resolvedParams = await Promise.resolve(params);
+  const post = getPostBySlug(resolvedParams.slug);
 
   if (!post) {
     notFound();

--- a/src/components/navigation/MobileMenu.tsx
+++ b/src/components/navigation/MobileMenu.tsx
@@ -3,22 +3,29 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { MobileMenuProps } from "@/types/navigation";
+import { useState, useEffect } from "react";
+import ReactDOM from "react-dom";
 
 export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
 
-  if (!isOpen) return null;
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-  return (
+  if (!mounted || !isOpen) return null;
+
+  return ReactDOM.createPortal(
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/20 backdrop-blur-sm sm:hidden"
+        className="fixed inset-0 bg-black/20 backdrop-blur-sm sm:hidden z-[1000]"
         onClick={onClose}
       />
 
       {/* Sidebar */}
-      <div className="fixed inset-y-0 left-0 w-64 bg-white shadow-lg sm:hidden">
+      <div className="fixed inset-y-0 left-0 w-64 bg-white shadow-lg sm:hidden z-[1001]">
         <div className="flex h-16 items-center justify-between px-4">
           <Link href="/" className="text-xl font-bold text-gray-900">
             Blog Platform
@@ -87,6 +94,7 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
           </div>
         </nav>
       </div>
-    </>
+    </>,
+    document.body,
   );
 }

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -25,3 +25,5 @@ export interface Post {
 export interface PostListProps {
   posts: Post[];
 }
+
+export type PostParams = Promise<{ slug: string }>;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -19,7 +19,7 @@ export interface Post {
     name: string;
     image: string;
   };
-  coverImage?: string;
+  coverImage: string;
 }
 
 export interface PostListProps {


### PR DESCRIPTION
## Context:
The blog cover image was overlapping the mobile sidebar on mobile devices, leading to poor user experience. Additionally, individual blog post pages were needed so that users can view full post details using dynamic routing.

## Intent:
- Added a dynamic Blog Post Page under /src/app/blog/[slug]/page.tsx to retrieve and display post details including title, cover image, excerpt, and author info. This page also handles the 404 case when a post is not found.
- Refactored the MobileMenu component by converting it to use ReactDOM.createPortal, ensuring that its stacking context is isolated from the rest of the page.
- Updated the MobileMenu component with proper state management (useState/useEffect) to wait for mounting before rendering.
- Adjusted z-index values: set the backdrop to z-[1000] and the sidebar to z-[1001] to prevent the blog post cover image (with z-0) from overlapping the mobile menu.

## Note:
These changes provide a smoother mobile experience and add essential blog post functionality while following proper UI layering practices.